### PR TITLE
Allow custom configuration of repo source

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -1,0 +1,20 @@
+---
+module:
+  repo: https://github.com/enovance/puppet-openstack-cloud
+  commit: master
+infrastructure:
+  repo: https://github.com/enovance/openstack-yaml-infra.git
+  commit: master
+serverspec:
+  repo: https://github.com/enovance/openstack-serverspec.git
+  commit: master
+configtools:
+  repo: https://github.com/enovance/config-tools.git
+  commit: master
+jenkins:
+  repo: https://github.com/enovance/jjb-openstack.git
+  commit: master
+env:
+  repo: https://github.com/Spredzy/spinalstack-env.git
+  commit: master
+

--- a/roles/install-server/tasks/main.yml
+++ b/roles/install-server/tasks/main.yml
@@ -24,14 +24,41 @@
   copy: src=hosts
         dest=/etc/hosts
 
-- name: Retrieve public repositories (eNovance)
-  git:  repo=https://github.com/enovance/{{ item }}.git
-        dest=/tmp/{{ item }}
-  with_items:
-    - openstack-yaml-infra
-    - puppet-openstack-cloud
-    - openstack-serverspec
-    - config-tools 
+- name: Retrieve puppet-openstack-cloud module
+  git:  repo="{{ module.repo }}"
+        dest=/tmp/puppet-openstack-cloud
+        version="{{ module.commit }}"
+  with_dict: module
+
+- name: Retrieve openstack-yaml-infra
+  git:  repo="{{ infrastructure.repo }}"
+        dest=/tmp/openstack-yaml-infra
+        version="{{ infrastructure.commit }}"
+  with_dict: infrastructure
+
+- name: Retrieve serverspec
+  git:  repo="{{ serverspec.repo }}"
+        dest=/tmp/openstack-serverspec
+        version="{{ serverspec.commit }}"
+  with_dict: serverspec
+
+- name: Retrieve config-tools
+  git:  repo="{{ configtools.repo }}"
+        dest=/tmp/config-tools
+        version="{{ configtools.commit }}"
+  with_dict: configtools
+
+- name: Retrieve jenkins jobs
+  git:  repo="{{ jenkins.repo }}"
+        dest=/etc/jenkins_jobs
+        version="{{ jenkins.commit }}"
+  with_dict: jenkins
+
+- name: Retrieve env
+  git:  repo="{{ env.repo }}"
+        dest=/tmp/spinalstack-env
+        version="{{ env.commit }}"
+  with_dict: env
 
 - name: Ensure Jenkins is sudoer with no password
   lineinfile: dest=/etc/sudoers.d/jenkins create=yes line="jenkins ALL=(ALL) NOPASSWD:ALL"
@@ -39,18 +66,7 @@
 - name: Install autojenkins pip
   pip: name=autojenkins
 
-- name: Retrieve JJB jobs
-  git:  repo=https://github.com/enovance/{{ item }}.git
-        dest=/etc/jenkins_jobs
-  with_items:
-    - jjb-openstack
-
-- name: Retrieve custom repositories (Spredzy)
-  git:  repo=https://github.com/Spredzy/{{ item }}.git
-        dest=/tmp/{{ item }}
-  with_items:
-    - spinalstack-env
-
+# Scipts
 - name: Copy the scripts file
   command: cp /tmp/config-tools/{{ item }} /usr/bin/
   with_items:


### PR DESCRIPTION
Currently repo origin and branch are hard coded within the
playbook. With this commit simply by creating a group_Vars/installserver
file with custom origin will make the playbook pick up those specified
repositories.
